### PR TITLE
Time to move on from command files

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -6,17 +6,9 @@ FastShell utilises open source components running on the Terminal/command-line f
 1. Install [Node.js](http://nodejs.org/download), [Sass](http://sass-lang.com/tutorial.html) and [Git](http://git-scm.com) on your machine. If you're a Windows user you'll also need to install [Ruby](http://rubyinstaller.org/downloads).
 2. [Install Gulp](http://Gulpjs.com/) using `npm install -g gulp`. You may need to use `sudo` in front of the Gulp install command to give it permissions.
 3. Fork/Clone/Download the FastShell repository into your machine, you should hopefully see all the files and folders.
-4. Navigate to the `gulp-dev.command` file and double-click it. This will open the Terminal and install the necessary `node_modules` folder, which are FastShell's dependencies. The `gulp-dev.command` file includes a `sudo` prefix so you'll need to enter your password to install.
-5. The `gulp-dev.command` should install all the dependencies, which you can check back to see in your folder, and then run the commands associated with FastShell, and automatically open a new FastShell project running on `localhost:3002`.
-6. From now on, just double-click the `gulp-dev.command` file to automatically run FastShell's Gulp tasks, it's setup using the following script to automatically `cd` you into the correct directory and run the necessary commands:
-
-````sh
-cd "$(dirname "$0")"
-if [ ! -d node_modules ];then
-    sudo npm install
-fi
-gulp
-````
+4. Open Terminal and install FastShell's dependencies to `node_modules` directory in your project directory using `npm install`. You don't need `sudo` to do this.
+5. The `npm install` you did in previous step should install all the dependencies, which you can confirm by visiting the `node_modules` in your project directory. Then use `gulp` (again in your project directory) to run the commands associated with FastShell and to automatically open a new FastShell project running on `localhost:3002`.
+6. From now on, just run `gulp` in your project directory to automatically run FastShell's Gulp tasks.
 
 ## How to use FastShell
 Using FastShell is very easy, it's based on an easy philosphy of keeping things simple so that anybody can use it, even with zero experience on the command-line. FastShell uses Gulp to manage all the essential tasks for building with the web.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Fiercely quick front-end boilerplate and workflows.
 The opinionated FastShell framework. Built for the modern developer. For teams and the individual, encouraging a better workflow. JavaScript task running, build processes, autominification and file concatenation, wrapped with an enhanced HTML5 boilerplated framework.
 
 * Source: [github.com/HosseinKarami/fastshell](http://github.com/HosseinKarami/fastshell)
-* Documentation: [Docs.md](https://github.com/HosseinKarami/fastshell/blob/master/docs/DOCS.md)
+* Documentation: [DOCS.md](https://github.com/HosseinKarami/fastshell/blob/master/DOCS.md)
 * HomePage: [Fastshell](https://HosseinKarami.github.io/fastshell)
 
 

--- a/gulp-dev.bat
+++ b/gulp-dev.bat
@@ -1,3 +1,0 @@
-@echo off
-IF not exist node_modules (npm install)
-gulp

--- a/gulp-dev.command
+++ b/gulp-dev.command
@@ -1,5 +1,0 @@
-cd "$(dirname "$0")"
-if [ ! -d node_modules ];then
-    sudo npm install
-fi
-gulp


### PR DESCRIPTION
The user will *have to* use the command line at some point, so why to make them to be afraid of it. I believe this commit will also help user to understand the simplicity of the build process.

* Deleted `gulp-dev.*` files
* Edited `DOCS.md` to reflect the simplified process
* Moved `DOCS.md` to main dir (because why not), and edited `README.md` to reflect the change
* This also closes #4 because sudo is absolutely not needed to install local NPM dependencies