### PR TITLE
Gulp crash when sass find errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ var banner = [
 
 gulp.task('css', function () {
     return gulp.src('src/scss/style.scss')
-    .pipe(sass({errLogToConsole: true}))
+    .pipe(sass().on('error', sass.logError))
     .pipe(autoprefixer('last 4 version'))
     .pipe(gulp.dest('app/assets/css'))
     .pipe(cssnano())


### PR DESCRIPTION
According to https://github.com/dlmanning/gulp-sass/issues/251, because we are using "gulp-sass": "^2.1.1", errLogToConsole doesnt seem to be our solution here. Instead, we need to call on('error', ...