### PR TITLE
Watch entire scss directory

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ gulp.task('bs-reload', function () {
 });
 
 gulp.task('default', ['css', 'js', 'browser-sync'], function () {
-    gulp.watch("src/scss/*/*.scss", ['css']);
+    gulp.watch("src/scss/**/*.scss", ['css']);
     gulp.watch("src/js/*.js", ['js']);
     gulp.watch("app/*.html", ['bs-reload']);
 });


### PR DESCRIPTION
Need to change the glob to /**/*.scss otherwise the main style.scss file won't be watched for changes. See node-glob docs:

> `**` If a "globstar" is alone in a path portion, then it matches zero or more directories and subdirectories searching for matches. It does not crawl symlinked directories.